### PR TITLE
Set submesh count when assigning triangles via AddSubMeshTriangles

### DIFF
--- a/Scripts/MeshSimplifier.cs
+++ b/Scripts/MeshSimplifier.cs
@@ -1069,6 +1069,8 @@ namespace UnityMeshSimplifier
 
                 triangleIndex += subMeshTriangleCount;
             }
+
+            subMeshCount = triangles.Length;
         }
         #endregion
 


### PR DESCRIPTION
It's already set when using Initialize with a mesh, but it wasn't being set when manually setting the submesh triangles.