### PR TITLE
Fixed compile error on versions of Unity less than 2019.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [v2.0.0]
+## [Unreleased]
+### Fixed
+- Fixed compile error on versions of Unity less than 2019.1
+
+## [v2.0.0] - 2019-07-07
 ### Added
 - Unity package manifest file.
 - LOD generator.

--- a/Editor/Whinarn.UnityMeshSimplifier.Editor.asmdef
+++ b/Editor/Whinarn.UnityMeshSimplifier.Editor.asmdef
@@ -1,7 +1,7 @@
 {
     "name": "Whinarn.UnityMeshSimplifier.Editor",
     "references": [
-        "GUID:77ccaf49895b0d64e87cd4b4faf83c49"
+        "Whinarn.UnityMeshSimplifier.Runtime"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [

--- a/Runtime/Whinarn.UnityMeshSimplifier.Runtime.asmdef
+++ b/Runtime/Whinarn.UnityMeshSimplifier.Runtime.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "UnityMeshSimplifier",
+    "name": "Whinarn.UnityMeshSimplifier.Runtime",
     "references": [],
     "optionalUnityReferences": [],
     "includePlatforms": [],


### PR DESCRIPTION
Referencing assembly definition files by GUID was only added in Unity 2019.1 so having the `Whinarn.UnityMeshSimplifier.Editor` assembly reference the `Whinarn.UnityMeshSimplifier.Runtime` assembly by GUID instead of by name causes a compiler error on versions of Unity less than 2019.1.

This PR changes the reference back to using the assembly name.