### PR TITLE
Allow specification of used UV channel count

### DIFF
--- a/Runtime/LODGenerator.cs
+++ b/Runtime/LODGenerator.cs
@@ -598,6 +598,7 @@ namespace UnityMeshSimplifier
             meshSimplifier.PreserveUVSeamEdges = options.PreserveUVSeamEdges;
             meshSimplifier.PreserveUVFoldoverEdges = options.PreserveUVFoldoverEdges;
             meshSimplifier.EnableSmartLink = options.EnableSmartLink;
+            meshSimplifier.UsedUVComponentCount = options.UsedUVComponentCount;
             meshSimplifier.VertexLinkDistance = options.VertexLinkDistance;
             meshSimplifier.MaxIterationCount = options.MaxIterationCount;
             meshSimplifier.Agressiveness = options.Agressiveness;

--- a/Runtime/MeshSimplifier.cs
+++ b/Runtime/MeshSimplifier.cs
@@ -411,6 +411,7 @@ namespace UnityMeshSimplifier
         private bool preserveUVSeamEdges = false;
         private bool preserveUVFoldoverEdges = false;
         private bool enableSmartLink = true;
+        private int usedUVComponentCount = 0;
         private int maxIterationCount = 100;
         private double agressiveness = 7.0;
         private bool verbose = false;
@@ -513,6 +514,16 @@ namespace UnityMeshSimplifier
         {
             get { return enableSmartLink; }
             set { enableSmartLink = value; }
+        }
+
+        /// <summary>
+        /// Defines how many UV components are used. 0 means UV components are automatically detected.
+        /// Default value: 0 (auto)
+        /// </summary>
+        public int UsedUVComponentCount
+        {
+            get { return usedUVComponentCount; }
+            set { usedUVComponentCount = Mathf.Clamp(value, 0, 4); }
         }
 
         /// <summary>
@@ -2257,7 +2268,7 @@ namespace UnityMeshSimplifier
 
             if (uvs != null && uvs.Count > 0)
             {
-                int usedComponents = MeshUtils.GetUsedUVComponents(uvs);
+                int usedComponents = usedUVComponentCount == 0 ? MeshUtils.GetUsedUVComponents(uvs) : usedUVComponentCount;
                 if (usedComponents <= 2)
                 {
                     var uv2D = MeshUtils.ConvertUVsTo2D(uvs);

--- a/Runtime/SimplificationOptions.cs
+++ b/Runtime/SimplificationOptions.cs
@@ -44,6 +44,7 @@ namespace UnityMeshSimplifier
             PreserveUVSeamEdges = false,
             PreserveUVFoldoverEdges = false,
             EnableSmartLink = true,
+            UsedUVComponentCount = 0,
             VertexLinkDistance = double.Epsilon,
             MaxIterationCount = 100,
             Agressiveness = 7.0
@@ -75,6 +76,12 @@ namespace UnityMeshSimplifier
         /// </summary>
         [Tooltip("If a feature for smarter vertex linking should be enabled, reducing artifacts at the cost of slower simplification.")]
         public bool EnableSmartLink;
+        /// <summary>
+        /// By default (if this value is 0), used UV components are automatically detected. Set them here if that introduces issues.
+        /// </summary>
+        [Tooltip("Number of UV Components used. 0 means automatic detection will be used.")]
+        [Range(0,4)]
+        public int UsedUVComponentCount;
         /// <summary>
         /// The maximum distance between two vertices in order to link them.
         /// Note that this value is only used if EnableSmartLink is true.


### PR DESCRIPTION
This is a WIP that fixes https://github.com/Whinarn/UnityMeshSimplifier/issues/22. While it allows to work around the issue, it has the following drawbacks:
- UV component count is specified for all components, not just for the ones where it would need to be
- adding another UI option for such an arcance usecase seems to not be right
- having the default of "0" be the magic number where autodetection is used should look better in the UI

![image](https://user-images.githubusercontent.com/2693840/66674897-6e203500-ec64-11e9-8da8-1fa34657509f.png)
