### PR TITLE
Improved the core model simplification algorithm

### DIFF
--- a/Runtime/LODGenerator.cs
+++ b/Runtime/LODGenerator.cs
@@ -597,11 +597,11 @@ namespace UnityMeshSimplifier
             meshSimplifier.PreserveBorderEdges = options.PreserveBorderEdges;
             meshSimplifier.PreserveUVSeamEdges = options.PreserveUVSeamEdges;
             meshSimplifier.PreserveUVFoldoverEdges = options.PreserveUVFoldoverEdges;
+            meshSimplifier.PreserveSurfaceCurvature = options.PreserveSurfaceCurvature;
             meshSimplifier.EnableSmartLink = options.EnableSmartLink;
             meshSimplifier.VertexLinkDistance = options.VertexLinkDistance;
             meshSimplifier.MaxIterationCount = options.MaxIterationCount;
             meshSimplifier.Agressiveness = options.Agressiveness;
-
             meshSimplifier.Initialize(mesh);
             meshSimplifier.SimplifyMesh(quality);
 

--- a/Runtime/MeshSimplifier.cs
+++ b/Runtime/MeshSimplifier.cs
@@ -815,18 +815,15 @@ namespace UnityMeshSimplifier
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private double CurvatureError(Vertex Vi, Vertex Vj)
+        private double CurvatureError(ref Vertex Vi, ref Vertex Vj)
         {
-            //System.Diagnostics.Stopwatch w = new System.Diagnostics.Stopwatch();
-            //w.Start();
-
             double diffVector = (Vi.p - Vj.p).Magnitude;
 
-            HashSet<Triangle> trianglesWithVi = GetTrianglesContainingVertex(Vi);
-            HashSet<Triangle> trianglesWithVj = GetTrianglesContainingVertex(Vj);
+            HashSet<Triangle> trianglesWithVi = GetTrianglesContainingVertex(ref Vi);
+            HashSet<Triangle> trianglesWithVj = GetTrianglesContainingVertex(ref Vj);
             HashSet<Triangle> trianglesWithViOrVjOrBoth = new HashSet<Triangle>(trianglesWithVi);
             trianglesWithViOrVjOrBoth.UnionWith(trianglesWithVj);
-            HashSet<Triangle> trianglesWithViAndVjBoth = GetTrianglesContainingBothVertices(Vi, Vj);
+            HashSet<Triangle> trianglesWithViAndVjBoth = GetTrianglesContainingBothVertices(ref Vi, ref Vj);
 
 
             double maxDotOuter = 0;
@@ -834,24 +831,21 @@ namespace UnityMeshSimplifier
             foreach (var triangleWithViOrVjOrBoth in trianglesWithViOrVjOrBoth)
             {
                 double maxDotInner = 0;
-
-                Vector3 normVecWithViOrVjOrBoth = GetTriangleNormalVector(triangleWithViOrVjOrBoth);
+                
+                Vector3d normVecTriangleWithViOrVjOrBoth = triangleWithViOrVjOrBoth.n;
 
                 foreach (var triangleWithViAndVjBoth in trianglesWithViAndVjBoth)
                 {
-                    Vector3 normVecTriangleWithViAndVjBoth = GetTriangleNormalVector(triangleWithViAndVjBoth);
+                    Vector3d normVecTriangleWithViAndVjBoth = triangleWithViAndVjBoth.n;
 
-                    double dot = Vector3.Dot(normVecWithViOrVjOrBoth, normVecTriangleWithViAndVjBoth);
-
+                    double dot = Vector3d.Dot(ref normVecTriangleWithViOrVjOrBoth, ref normVecTriangleWithViAndVjBoth);
+                    
                     if (dot > maxDotInner) { maxDotInner = dot; }
                 }
 
                 if (maxDotInner > maxDotOuter) { maxDotOuter = maxDotInner; }
 
             }
-
-            //w.Stop();
-            //Debug.Log("Time ellapsed =  " + w.ElapsedMilliseconds);
 
             return diffVector * maxDotOuter;
         }
@@ -873,10 +867,10 @@ namespace UnityMeshSimplifier
                     -1.0 / det * q.Determinant4()); // vz = A43/det(q_delta)
 
                 double curvatureError = 0;
-
+                
                 if (preserveSurfaceCurvature)
                 {
-                    curvatureError = CurvatureError(vert0, vert1);
+                    curvatureError = CurvatureError(ref vert0, ref vert1);
                 }
 
                 error = VertexError(ref q, result.x, result.y, result.z) + curvatureError;
@@ -1743,9 +1737,9 @@ namespace UnityMeshSimplifier
         }
         #endregion
 
-        #region Traingle helper functions
+        #region Triangle helper functions
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private HashSet<Triangle> GetTrianglesContainingVertex(Vertex toCheck)
+        private HashSet<Triangle> GetTrianglesContainingVertex(ref Vertex toCheck)
         {
             int trianglesCount = toCheck.tcount;
             int startIndex = toCheck.tstart;
@@ -1762,7 +1756,7 @@ namespace UnityMeshSimplifier
 
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private HashSet<Triangle> GetTrianglesContainingBothVertices(Vertex vertex1, Vertex vertex2)
+        private HashSet<Triangle> GetTrianglesContainingBothVertices(ref Vertex vertex1, ref Vertex vertex2)
         {
             HashSet<Triangle> tris = new HashSet<Triangle>();
 
@@ -1793,31 +1787,7 @@ namespace UnityMeshSimplifier
         }
 
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private Vector3 GetTriangleNormalVector(Triangle triangle)
-        {
-            Vector3 normal = Vector3.zero;
-
-            Vertex V0 = vertices[triangle.v0];
-            Vertex V1 = vertices[triangle.v1];
-            Vertex V2 = vertices[triangle.v2];
-
-            Vector3 a = new Vector3((float)V0.p.x, (float)V0.p.y, (float)V0.p.z);
-            Vector3 b = new Vector3((float)V1.p.x, (float)V1.p.y, (float)V1.p.z);
-            Vector3 c = new Vector3((float)V2.p.x, (float)V2.p.y, (float)V2.p.z);
-
-
-            Vector3 side1 = b - a;
-            Vector3 side2 = c - a;
-
-            Vector3 perp = Vector3.Cross(side1, side2);
-
-            float perpLength = perp.magnitude;
-            normal = perp / perpLength;
-
-            return normal;
-        }
-        #endregion Traingle helper functions
+        #endregion Triangle helper functions
 
 
         #endregion

--- a/Runtime/MeshSimplifier.cs
+++ b/Runtime/MeshSimplifier.cs
@@ -504,7 +504,6 @@ namespace UnityMeshSimplifier
             set { preserveUVFoldoverEdges = value; }
         }
 
-
         /// <summary>
         /// Gets or sets if the discrete curvature of the mesh surface be taken into account during simplification.
         /// Default value: false

--- a/Runtime/SimplificationOptions.cs
+++ b/Runtime/SimplificationOptions.cs
@@ -43,6 +43,7 @@ namespace UnityMeshSimplifier
             PreserveBorderEdges = false,
             PreserveUVSeamEdges = false,
             PreserveUVFoldoverEdges = false,
+            PreserveSurfaceCurvature = false,
             EnableSmartLink = true,
             VertexLinkDistance = double.Epsilon,
             MaxIterationCount = 100,
@@ -67,6 +68,12 @@ namespace UnityMeshSimplifier
         /// </summary>
         [Tooltip("If the UV foldover edges should be preserved.")]
         public bool PreserveUVFoldoverEdges;
+        /// <summary>
+        /// If the discrete curvature of the mesh surface be taken into account during simplification. Taking surface curvature into account can result in good quality mesh simplification, but it can slow the simplification process significantly.
+        /// Default value: false
+        /// </summary>
+        [Tooltip("If the discrete curvature of the mesh surface be taken into account during simplification. Taking surface curvature into account can result in very good quality mesh simplification, but it can slow the simplification process significantly.")]
+        public bool PreserveSurfaceCurvature;
         /// <summary>
         /// If a feature for smarter vertex linking should be enabled, reducing artifacts in the
         /// decimated result at the cost of a slightly more expensive initialization by treating vertices at


### PR DESCRIPTION
Hi, these changes are based on a research paper that augments the original paper by Dr Garland. You can read it here: https://www.hindawi.com/journals/mpe/2015/428917/. This also solves the issue listed here to some extent https://github.com/Whinarn/UnityMeshSimplifier/issues/19. See for yourself below.

**BEFORE MY CHANGES**

_**LOD Level (Quality 0.55 - Total Triangles after reduction 1208)ca**_

![Capture](https://user-images.githubusercontent.com/56951266/76941753-6608a780-691e-11ea-8e97-62818baa535d.PNG)


**AFTER MY CHANGES**

_**LOD Level (Quality 0.55 - Total Triangles after reduction 1208)ca**_

![Capture2](https://user-images.githubusercontent.com/56951266/76941809-7de02b80-691e-11ea-8402-36e8bf803ee0.PNG)

Please note that this is not meant to exclusively solve the boat problem originally reported here
https://github.com/Whinarn/UnityMeshSimplifier/issues/19. In fact the issue with the boat model is still there and something tells me that it's related to the vertex linking.