### PR TITLE
Reduce maximum commit message length to 72

### DIFF
--- a/.github/workflows/commit_message_check.yml
+++ b/.github/workflows/commit_message_check.yml
@@ -12,10 +12,10 @@ jobs:
       - name: Check Commit Type And Scope
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '[a-z]+(?:\([a-z]+\))?: .+(?:\n(?:\n.+)+)?(?:\n\n.+)?$'
+          pattern: '^[a-z]+(?:\([a-z]+\))?: .+(?:\n(?:\n.+)+)?(?:\n\n.+)?$'
           error: 'Your message must have the correct format "<type>(<scope>): <subject>" with an optional body and footer separated by blank lines.'
       - name: Check Line Length
         uses: gsactions/commit-message-checker@v1
         with:
-          pattern: '^[^#].{100}'
+          pattern: '^.{1,72}(?:\n.{0,72})*$'
           error: 'The maximum line length of 100 characters is exceeded.'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ Every commit must specify at least a **type** and a **subject**. While **scope**
 <footer>
 ```
 
-Any line of the commit message cannot be longer than 100 characters, in order for them to be easy to read in varios git tools.
+Any line of the commit message cannot be longer than 72 characters, in order for them to be easy to read in varios git tools.
 
 **Examples:**
 


### PR DESCRIPTION
Also fixed some regex problems with checking commit messages.