### PR TITLE
References update

### DIFF
--- a/Runtime/MeshSimplifier.cs
+++ b/Runtime/MeshSimplifier.cs
@@ -1176,14 +1176,11 @@ namespace UnityMeshSimplifier
                 int v1 = triangles[i].v1;
                 int v2 = triangles[i].v2;
                 int start0 = vertices[v0].tstart;
-                int count0 = vertices[v0].tcount;
-                ++vertices[v0].tcount;
+                int count0 = vertices[v0].tcount++;
                 int start1 = vertices[v1].tstart;
-                int count1 = vertices[v1].tcount;
-                ++vertices[v1].tcount;
+                int count1 = vertices[v1].tcount++;
                 int start2 = vertices[v2].tstart;
-                int count2 = vertices[v2].tcount;
-                ++vertices[v2].tcount;
+                int count2 = vertices[v2].tcount++;
 
                 refs[start0 + count0].Set(i, 0);
                 refs[start1 + count1].Set(i, 1);

--- a/Runtime/MeshSimplifier.cs
+++ b/Runtime/MeshSimplifier.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 /*
 MIT License
 
@@ -1177,18 +1177,17 @@ namespace UnityMeshSimplifier
                 int v2 = triangles[i].v2;
                 int start0 = vertices[v0].tstart;
                 int count0 = vertices[v0].tcount;
+                ++vertices[v0].tcount;
                 int start1 = vertices[v1].tstart;
                 int count1 = vertices[v1].tcount;
+                ++vertices[v1].tcount;
                 int start2 = vertices[v2].tstart;
                 int count2 = vertices[v2].tcount;
+                ++vertices[v2].tcount;
 
                 refs[start0 + count0].Set(i, 0);
                 refs[start1 + count1].Set(i, 1);
                 refs[start2 + count2].Set(i, 2);
-
-                ++vertices[v0].tcount;
-                ++vertices[v1].tcount;
-                ++vertices[v2].tcount;
             }
         }
         #endregion


### PR DESCRIPTION
**Reference array is not initialized properly for a degenerated triangle when using smart linking**
Smart linking can merge two very close triangle vertices together. For instance a triangle T(a,b,c) could become T(a,a,c) after smart linking. The UpdateReferences() function do not update the refs[] array correctly in this case because it overwrites the same ref cell twice and leaves the second ref cell not initialized because the indexer is updated only at the end of the function.

