### PR TITLE
Fix compile errors on 2018.4.26f1

### DIFF
--- a/Tests/Editor/MeshUtilsTest.cs
+++ b/Tests/Editor/MeshUtilsTest.cs
@@ -412,7 +412,11 @@ namespace UnityMeshSimplifier.Editor.Tests
             mesh.vertices = new Vector3[4];
             for (int i = 0; i < uvs.Length; i++)
             {
+#if UNITY_2018
+                mesh.SetUVs(i, uvs[i].ToList());
+#else
                 mesh.SetUVs(i, uvs[i]);
+#endif
             }
 
             var allUVs = MeshUtils.GetMeshUVs(mesh);

--- a/Tests/Editor/Whinarn.UnityMeshSimplifier.Editor.Tests.asmdef
+++ b/Tests/Editor/Whinarn.UnityMeshSimplifier.Editor.Tests.asmdef
@@ -1,7 +1,10 @@
 {
     "name": "Whinarn.UnityMeshSimplifier.Editor.Tests",
     "references": [
-        "GUID:77ccaf49895b0d64e87cd4b4faf83c49"
+            "Whinarn.UnityMeshSimplifier.Runtime"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
     ],
     "includePlatforms": [
         "Editor"
@@ -11,7 +14,5 @@
     "overrideReferences": false,
     "precompiledReferences": [],
     "autoReferenced": true,
-    "defineConstraints": [],
-    "versionDefines": [],
-    "noEngineReferences": false
+    "defineConstraints": []
 }


### PR DESCRIPTION
**Related issues**
Somewhat related to a community contribution to Unity-Technologies/AutoLOD#74

**Describe the changes**
A few small fixes:
* GUIDs don't work in 2018 asmdefs
* TestAssemblies checkbox required for 2018
* Compile error on 2018

**How to test**
You can verify with 2018.4.26f1 by editing the manifest.json to pull the package/branch from github or clone locally to `Packages/`