### PR TITLE
Unrestricted save assets path

### DIFF
--- a/Editor/LODGeneratorHelperEditor.cs
+++ b/Editor/LODGeneratorHelperEditor.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 /*
 MIT License
 
@@ -140,10 +140,10 @@ namespace UnityMeshSimplifier.Editor
             EditorGUILayout.PropertyField(autoCollectRenderersProperty);
             DrawSimplificationOptions();
 
-            bool newHasSaveAssetsPath = EditorGUILayout.Toggle(overrideSaveAssetsPathContent, overrideSaveAssetsPath);
-            if (newHasSaveAssetsPath != overrideSaveAssetsPath)
+            bool newOverrideSaveAssetsPath = EditorGUILayout.Toggle(overrideSaveAssetsPathContent, overrideSaveAssetsPath);
+            if (newOverrideSaveAssetsPath != overrideSaveAssetsPath)
             {
-                overrideSaveAssetsPath = newHasSaveAssetsPath;
+                overrideSaveAssetsPath = newOverrideSaveAssetsPath;
                 saveAssetsPathProperty.stringValue = string.Empty;
                 serializedObject.ApplyModifiedProperties();
                 GUIUtility.ExitGUI();
@@ -151,7 +151,12 @@ namespace UnityMeshSimplifier.Editor
 
             if (overrideSaveAssetsPath)
             {
+                EditorGUI.BeginChangeCheck();
                 EditorGUILayout.PropertyField(saveAssetsPathProperty);
+                if (EditorGUI.EndChangeCheck())
+                {
+                    saveAssetsPathProperty.stringValue = IOUtils.MakeSafeRelativePath(saveAssetsPathProperty.stringValue);
+                }
             }
 
             if (settingsExpanded == null || settingsExpanded.Length != levelsProperty.arraySize)

--- a/Editor/Whinarn.UnityMeshSimplifier.Editor.asmdef
+++ b/Editor/Whinarn.UnityMeshSimplifier.Editor.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Whinarn.UnityMeshSimplifier.Editor",
+    "rootNamespace": "UnityMeshSimplifier.Editor",
     "references": [
         "Whinarn.UnityMeshSimplifier.Runtime"
     ],

--- a/Runtime/AssemblyAttributes.cs
+++ b/Runtime/AssemblyAttributes.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly:InternalsVisibleTo("Whinarn.UnityMeshSimplifier.Editor")]

--- a/Runtime/AssemblyAttributes.cs.meta
+++ b/Runtime/AssemblyAttributes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4d1ea4d1aec680349b9da9df1024ecbc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Components/LODGeneratorHelper.cs
+++ b/Runtime/Components/LODGeneratorHelper.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 /*
 MIT License
 
@@ -46,7 +46,7 @@ namespace UnityMeshSimplifier
         [SerializeField, Tooltip("The simplification options.")]
         private SimplificationOptions simplificationOptions = SimplificationOptions.Default;
 
-        [SerializeField, Tooltip("The path within the project to save the generated assets. Leave this empty to use the default path.")]
+        [SerializeField, Tooltip("The path within the assets directory to save the generated assets. Leave this empty to use the default path.")]
         private string saveAssetsPath = string.Empty;
 
         [SerializeField, Tooltip("The LOD levels.")]

--- a/Runtime/LODGenerator.cs
+++ b/Runtime/LODGenerator.cs
@@ -35,26 +35,26 @@ namespace UnityMeshSimplifier
     /// </summary>
     public static class LODGenerator
     {
-        #region Consts
+        #region Static Read-Only
         /// <summary>
         /// The name of the game object where generated LODs are parented under.
         /// </summary>
-        public const string LODParentGameObjectName = "_UMS_LODs_";
+        public static readonly string LODParentGameObjectName = "_UMS_LODs_";
 
         /// <summary>
         /// The default parent path for generated LOD assets.
         /// </summary>
-        public const string LODAssetDefaultParentPath = AssetsRootPath + "UMS_LODs/";
+        public static readonly string LODAssetDefaultParentPath = AssetsRootPath + "UMS_LODs/";
 
         /// <summary>
         /// The root assets path.
         /// </summary>
-        public const string AssetsRootPath = "Assets/";
+        public static readonly string AssetsRootPath = "Assets/";
 
         /// <summary>
         /// The user data applied to created LOD assets.
         /// </summary>
-        public const string LODAssetUserData = "UnityMeshSimplifierLODAsset";
+        public static readonly string LODAssetUserData = "UnityMeshSimplifierLODAsset";
         #endregion
 
         #region Nested Types

--- a/Runtime/LODGenerator.cs
+++ b/Runtime/LODGenerator.cs
@@ -44,7 +44,7 @@ namespace UnityMeshSimplifier
         /// <summary>
         /// The default parent path for generated LOD assets.
         /// </summary>
-        public static readonly string LODAssetDefaultParentPath = AssetsRootPath + "UMS_LODs/";
+        public static readonly string LODAssetDefaultParentPath = "Assets/UMS_LODs/";
 
         /// <summary>
         /// The root assets path.

--- a/Runtime/LODGenerator.cs
+++ b/Runtime/LODGenerator.cs
@@ -700,6 +700,9 @@ namespace UnityMeshSimplifier
 
         private static void SaveLODMeshAsset(Object asset, string gameObjectName, string rendererName, int levelIndex, string meshName, string saveAssetsPath)
         {
+            if (string.IsNullOrEmpty(meshName))
+                meshName = "unnamed";
+
             gameObjectName = IOUtils.MakeSafeFileName(gameObjectName);
             rendererName = IOUtils.MakeSafeFileName(rendererName);
             meshName = IOUtils.MakeSafeFileName(meshName);

--- a/Runtime/Utility/IOUtils.cs
+++ b/Runtime/Utility/IOUtils.cs
@@ -1,0 +1,102 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace UnityMeshSimplifier
+{
+    internal static class IOUtils
+    {
+        internal static string MakeSafeRelativePath(string path)
+        {
+            if (string.IsNullOrEmpty(path))
+                return null;
+
+            path = path.Replace('\\', '/');
+            path = path.Trim('/');
+
+            if (Path.IsPathRooted(path))
+                throw new ArgumentException("The path cannot be rooted.", "path");
+
+            // Make the path safe
+            var pathParts = path.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            for (int i = 0; i < pathParts.Length; i++)
+            {
+                pathParts[i] = MakeSafeFileName(pathParts[i]);
+            }
+            return string.Join("/", pathParts);
+        }
+
+        internal static string MakeSafeFileName(string name)
+        {
+            char[] invalidFileNameChars = Path.GetInvalidFileNameChars();
+
+            var sb = new StringBuilder(name.Length);
+            bool lastWasInvalid = false;
+            for (int i = 0; i < name.Length; i++)
+            {
+                char c = name[i];
+                if (!invalidFileNameChars.Contains(c))
+                {
+                    sb.Append(c);
+                }
+                else if (!lastWasInvalid)
+                {
+                    lastWasInvalid = true;
+                    sb.Append('_');
+                }
+            }
+            return sb.ToString();
+        }
+
+#if UNITY_EDITOR
+        internal static void CreateParentDirectory(string path)
+        {
+            int lastSlashIndex = path.LastIndexOf('/');
+            if (lastSlashIndex != -1)
+            {
+                string parentPath = path.Substring(0, lastSlashIndex);
+                if (!UnityEditor.AssetDatabase.IsValidFolder(parentPath))
+                {
+                    lastSlashIndex = parentPath.LastIndexOf('/');
+                    if (lastSlashIndex != -1)
+                    {
+                        string folderName = parentPath.Substring(lastSlashIndex + 1);
+                        string folderParentPath = parentPath.Substring(0, lastSlashIndex);
+                        CreateParentDirectory(parentPath);
+                        UnityEditor.AssetDatabase.CreateFolder(folderParentPath, folderName);
+                    }
+                    else
+                    {
+                        UnityEditor.AssetDatabase.CreateFolder(string.Empty, parentPath);
+                    }
+                }
+            }
+        }
+
+        internal static bool DeleteEmptyDirectory(string path)
+        {
+            bool deletedAllSubFolders = true;
+            var subFolders = UnityEditor.AssetDatabase.GetSubFolders(path);
+            for (int i = 0; i < subFolders.Length; i++)
+            {
+                if (!DeleteEmptyDirectory(subFolders[i]))
+                {
+                    deletedAllSubFolders = false;
+                }
+            }
+
+            if (!deletedAllSubFolders)
+                return false;
+            else if (!UnityEditor.AssetDatabase.IsValidFolder(path))
+                return true;
+
+            string[] assetGuids = UnityEditor.AssetDatabase.FindAssets(string.Empty, new string[] { path });
+            if (assetGuids.Length > 0)
+                return false;
+
+            return UnityEditor.AssetDatabase.DeleteAsset(path);
+        }
+#endif
+    }
+}

--- a/Runtime/Utility/IOUtils.cs
+++ b/Runtime/Utility/IOUtils.cs
@@ -12,14 +12,13 @@ namespace UnityMeshSimplifier
             if (string.IsNullOrEmpty(path))
                 return null;
 
-            path = path.Replace('\\', '/');
-            path = path.Trim('/');
+            path = path.Replace('\\', '/').Trim('/');
 
             if (Path.IsPathRooted(path))
                 throw new ArgumentException("The path cannot be rooted.", "path");
 
             // Make the path safe
-            var pathParts = path.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            var pathParts = path.Split(new [] { '/' }, StringSplitOptions.RemoveEmptyEntries);
             for (int i = 0; i < pathParts.Length; i++)
             {
                 pathParts[i] = MakeSafeFileName(pathParts[i]);

--- a/Runtime/Utility/IOUtils.cs.meta
+++ b/Runtime/Utility/IOUtils.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9fba50edc5b3fb34a9525e89206148b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Whinarn.UnityMeshSimplifier.Runtime.asmdef
+++ b/Runtime/Whinarn.UnityMeshSimplifier.Runtime.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Whinarn.UnityMeshSimplifier.Runtime",
+    "rootNamespace": "UnityMeshSimplifier",
     "references": [],
     "optionalUnityReferences": [],
     "includePlatforms": [],

--- a/Tests/Editor/Whinarn.UnityMeshSimplifier.Editor.Tests.asmdef
+++ b/Tests/Editor/Whinarn.UnityMeshSimplifier.Editor.Tests.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "Whinarn.UnityMeshSimplifier.Editor.Tests",
+    "rootNamespace": "UnityMeshSimplifier.Editor.Tests",
     "references": [
             "Whinarn.UnityMeshSimplifier.Runtime"
     ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.whinarn.unitymeshsimplifier",
   "displayName": "Unity Mesh Simplifier",
   "version": "2.3.6",
-  "unity": "2017.1",
+  "unity": "2018.1",
   "description": "Simplifies 3D meshes with ease. Works both in the editor and during runtime in builds.",
   "type": "library",
   "keywords": [


### PR DESCRIPTION
Previously save assets path was opinionated both in terms of structure but also directory and file names.

**BREAKING CHANGE:** save assets paths are now related to Assets/ rather
than Assets/UMS_LODS/

This will introduce a new major version.

Closes https://github.com/Whinarn/UnityMeshSimplifier/issues/45