### PR TITLE
Manual UV component count

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Mattias Edlund
+Copyright (c) 2017-2021 Mattias Edlund
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Runtime/LODGenerator.cs
+++ b/Runtime/LODGenerator.cs
@@ -597,6 +597,12 @@ namespace UnityMeshSimplifier
 
         private static Mesh SimplifyMesh(Mesh mesh, float quality, SimplificationOptions options)
         {
+            int uvComponentCount = -1;
+            if (options.ManualUVComponentCount)
+            {
+                uvComponentCount = options.UVComponentCount;
+            }
+
             var meshSimplifier = new MeshSimplifier();
             meshSimplifier.PreserveBorderEdges = options.PreserveBorderEdges;
             meshSimplifier.PreserveUVSeamEdges = options.PreserveUVSeamEdges;
@@ -606,7 +612,7 @@ namespace UnityMeshSimplifier
             meshSimplifier.VertexLinkDistance = options.VertexLinkDistance;
             meshSimplifier.MaxIterationCount = options.MaxIterationCount;
             meshSimplifier.Agressiveness = options.Agressiveness;
-            meshSimplifier.Initialize(mesh);
+            meshSimplifier.Initialize(mesh, uvComponentCount);
             meshSimplifier.SimplifyMesh(quality);
 
             var simplifiedMesh = meshSimplifier.ToMesh();

--- a/Runtime/MeshSimplifier.cs
+++ b/Runtime/MeshSimplifier.cs
@@ -2037,7 +2037,9 @@ namespace UnityMeshSimplifier
         /// Initializes the algorithm with the original mesh.
         /// </summary>
         /// <param name="mesh">The mesh.</param>
-        /// <param name="uvComponentCount">The count of UV components that are used on the mesh. -1 means that it will be automatically detected. Note that all UV channels would use the same UV component count.</param>
+        /// <param name="uvComponentCount">The count of UV components that are used on the mesh.
+        /// -1 means that it will be automatically detected.
+        /// Note that all UV channels would use the same UV component count.</param>
         public void Initialize(Mesh mesh, int uvComponentCount)
         {
             if (mesh == null)

--- a/Runtime/MeshSimplifier.cs
+++ b/Runtime/MeshSimplifier.cs
@@ -1732,151 +1732,7 @@ namespace UnityMeshSimplifier
         /// </summary>
         /// <param name="channel">The channel index.</param>
         /// <param name="uvs">The UVs.</param>
-        public void SetUVs(int channel, Vector2[] uvs)
-        {
-            if (channel < 0 || channel >= UVChannelCount)
-                throw new ArgumentOutOfRangeException(nameof(channel));
-
-            if (uvs != null && uvs.Length > 0)
-            {
-                if (vertUV2D == null)
-                    vertUV2D = new UVChannels<Vector2>();
-
-                int uvCount = uvs.Length;
-                var uvSet = vertUV2D[channel];
-                if (uvSet != null)
-                {
-                    uvSet.Resize(uvCount);
-                }
-                else
-                {
-                    uvSet = new ResizableArray<Vector2>(uvCount, uvCount);
-                    vertUV2D[channel] = uvSet;
-                }
-
-                var uvData = uvSet.Data;
-                uvs.CopyTo(uvData, 0);
-            }
-            else
-            {
-                if (vertUV2D != null)
-                {
-                    vertUV2D[channel] = null;
-                }
-            }
-
-            if (vertUV3D != null)
-            {
-                vertUV3D[channel] = null;
-            }
-            if (vertUV4D != null)
-            {
-                vertUV4D[channel] = null;
-            }
-        }
-
-        /// <summary>
-        /// Sets the UVs (3D) for a specific channel.
-        /// </summary>
-        /// <param name="channel">The channel index.</param>
-        /// <param name="uvs">The UVs.</param>
-        public void SetUVs(int channel, Vector3[] uvs)
-        {
-            if (channel < 0 || channel >= UVChannelCount)
-                throw new ArgumentOutOfRangeException(nameof(channel));
-
-            if (uvs != null && uvs.Length > 0)
-            {
-                if (vertUV3D == null)
-                    vertUV3D = new UVChannels<Vector3>();
-
-                int uvCount = uvs.Length;
-                var uvSet = vertUV3D[channel];
-                if (uvSet != null)
-                {
-                    uvSet.Resize(uvCount);
-                }
-                else
-                {
-                    uvSet = new ResizableArray<Vector3>(uvCount, uvCount);
-                    vertUV3D[channel] = uvSet;
-                }
-
-                var uvData = uvSet.Data;
-                uvs.CopyTo(uvData, 0);
-            }
-            else
-            {
-                if (vertUV3D != null)
-                {
-                    vertUV3D[channel] = null;
-                }
-            }
-
-            if (vertUV2D != null)
-            {
-                vertUV2D[channel] = null;
-            }
-            if (vertUV4D != null)
-            {
-                vertUV4D[channel] = null;
-            }
-        }
-
-        /// <summary>
-        /// Sets the UVs (4D) for a specific channel.
-        /// </summary>
-        /// <param name="channel">The channel index.</param>
-        /// <param name="uvs">The UVs.</param>
-        public void SetUVs(int channel, Vector4[] uvs)
-        {
-            if (channel < 0 || channel >= UVChannelCount)
-                throw new ArgumentOutOfRangeException(nameof(channel));
-
-            if (uvs != null && uvs.Length > 0)
-            {
-                if (vertUV4D == null)
-                    vertUV4D = new UVChannels<Vector4>();
-
-                int uvCount = uvs.Length;
-                var uvSet = vertUV4D[channel];
-                if (uvSet != null)
-                {
-                    uvSet.Resize(uvCount);
-                }
-                else
-                {
-                    uvSet = new ResizableArray<Vector4>(uvCount, uvCount);
-                    vertUV4D[channel] = uvSet;
-                }
-
-                var uvData = uvSet.Data;
-                uvs.CopyTo(uvData, 0);
-            }
-            else
-            {
-                if (vertUV4D != null)
-                {
-                    vertUV4D[channel] = null;
-                }
-            }
-
-            if (vertUV2D != null)
-            {
-                vertUV2D[channel] = null;
-            }
-            if (vertUV3D != null)
-            {
-                vertUV3D[channel] = null;
-            }
-        }
-
-        /// <summary>
-        /// Sets the UVs (2D) for a specific channel.
-        /// </summary>
-        /// <param name="channel">The channel index.</param>
-        /// <param name="uvs">The UVs.</param>
-        public void SetUVs(int channel, List<Vector2> uvs)
+        public void SetUVs(int channel, IList<Vector2> uvs)
         {
             if (channel < 0 || channel >= UVChannelCount)
                 throw new ArgumentOutOfRangeException(nameof(channel));
@@ -1924,7 +1780,7 @@ namespace UnityMeshSimplifier
         /// </summary>
         /// <param name="channel">The channel index.</param>
         /// <param name="uvs">The UVs.</param>
-        public void SetUVs(int channel, List<Vector3> uvs)
+        public void SetUVs(int channel, IList<Vector3> uvs)
         {
             if (channel < 0 || channel >= UVChannelCount)
                 throw new ArgumentOutOfRangeException(nameof(channel));
@@ -1972,7 +1828,7 @@ namespace UnityMeshSimplifier
         /// </summary>
         /// <param name="channel">The channel index.</param>
         /// <param name="uvs">The UVs.</param>
-        public void SetUVs(int channel, List<Vector4> uvs)
+        public void SetUVs(int channel, IList<Vector4> uvs)
         {
             if (channel < 0 || channel >= UVChannelCount)
                 throw new ArgumentOutOfRangeException(nameof(channel));
@@ -2016,24 +1872,26 @@ namespace UnityMeshSimplifier
         }
 
         /// <summary>
-        /// Sets the UVs for a specific channel and automatically detects the used components.
+        /// Sets the UVs for a specific channel with a specific count of UV components.
         /// </summary>
         /// <param name="channel">The channel index.</param>
         /// <param name="uvs">The UVs.</param>
-        public void SetUVsAuto(int channel, List<Vector4> uvs)
+        /// <param name="uvComponentCount">The count of UV components.</param>
+        public void SetUVs(int channel, IList<Vector4> uvs, int uvComponentCount)
         {
             if (channel < 0 || channel >= UVChannelCount)
                 throw new ArgumentOutOfRangeException(nameof(channel));
+            else if (uvComponentCount < 0 || uvComponentCount > 4)
+                throw new ArgumentOutOfRangeException(nameof(uvComponentCount));
 
-            if (uvs != null && uvs.Count > 0)
+            if (uvs != null && uvs.Count > 0 && uvComponentCount > 0)
             {
-                int usedComponents = MeshUtils.GetUsedUVComponents(uvs);
-                if (usedComponents <= 2)
+                if (uvComponentCount <= 2)
                 {
                     var uv2D = MeshUtils.ConvertUVsTo2D(uvs);
                     SetUVs(channel, uv2D);
                 }
-                else if (usedComponents == 3)
+                else if (uvComponentCount == 3)
                 {
                     var uv3D = MeshUtils.ConvertUVsTo3D(uvs);
                     SetUVs(channel, uv3D);
@@ -2058,6 +1916,20 @@ namespace UnityMeshSimplifier
                     vertUV4D[channel] = null;
                 }
             }
+        }
+
+        /// <summary>
+        /// Sets the UVs for a specific channel and automatically detects the used components.
+        /// </summary>
+        /// <param name="channel">The channel index.</param>
+        /// <param name="uvs">The UVs.</param>
+        public void SetUVsAuto(int channel, IList<Vector4> uvs)
+        {
+            if (channel < 0 || channel >= UVChannelCount)
+                throw new ArgumentOutOfRangeException(nameof(channel));
+
+            int uvComponentCount = MeshUtils.GetUsedUVComponents(uvs);
+            SetUVs(channel, uvs, uvComponentCount);
         }
         #endregion
         #endregion
@@ -2153,12 +2025,25 @@ namespace UnityMeshSimplifier
         #region Initialize
         /// <summary>
         /// Initializes the algorithm with the original mesh.
+        /// Will automatically detect the count of UV components used on the mesh.
         /// </summary>
         /// <param name="mesh">The mesh.</param>
         public void Initialize(Mesh mesh)
         {
+            Initialize(mesh, -1);
+        }
+
+        /// <summary>
+        /// Initializes the algorithm with the original mesh.
+        /// </summary>
+        /// <param name="mesh">The mesh.</param>
+        /// <param name="uvComponentCount">The count of UV components that are used on the mesh. -1 means that it will be automatically detected. Note that all UV channels would use the same UV component count.</param>
+        public void Initialize(Mesh mesh, int uvComponentCount)
+        {
             if (mesh == null)
                 throw new ArgumentNullException(nameof(mesh));
+            if (uvComponentCount < -1 || uvComponentCount > 4)
+                throw new ArgumentOutOfRangeException(nameof(uvComponentCount));
 
             this.Vertices = mesh.vertices;
             this.Normals = mesh.normals;
@@ -2170,8 +2055,34 @@ namespace UnityMeshSimplifier
 
             for (int channel = 0; channel < UVChannelCount; channel++)
             {
-                var uvs = MeshUtils.GetMeshUVs(mesh, channel);
-                SetUVsAuto(channel, uvs);
+                switch (uvComponentCount)
+                {
+                    case -1:
+                        {
+                            var uvs = MeshUtils.GetMeshUVs(mesh, channel);
+                            SetUVsAuto(channel, uvs);
+                            break;
+                        }
+                    case 1:
+                    case 2:
+                        {
+                            var uvs = MeshUtils.GetMeshUVs2D(mesh, channel);
+                            SetUVs(channel, uvs);
+                            break;
+                        }
+                    case 3:
+                        {
+                            var uvs = MeshUtils.GetMeshUVs3D(mesh, channel);
+                            SetUVs(channel, uvs);
+                            break;
+                        }
+                    case 4:
+                        {
+                            var uvs = MeshUtils.GetMeshUVs(mesh, channel);
+                            SetUVs(channel, uvs);
+                            break;
+                        }
+                }
             }
 
             var blendShapes = MeshUtils.GetMeshBlendShapes(mesh);
@@ -2329,6 +2240,7 @@ namespace UnityMeshSimplifier
             List<Vector2>[] uvs2D = null;
             List<Vector3>[] uvs3D = null;
             List<Vector4>[] uvs4D = null;
+
             if (vertUV2D != null)
             {
                 uvs2D = new List<Vector2>[UVChannelCount];

--- a/Runtime/MeshSimplifier.cs
+++ b/Runtime/MeshSimplifier.cs
@@ -110,17 +110,6 @@ namespace UnityMeshSimplifier
         /// Gets or sets if the border edges should be preserved.
         /// Default value: false
         /// </summary>
-        [Obsolete("Use the 'MeshSimplifier.PreserveBorderEdges' property instead.", false)]
-        public bool PreserveBorders
-        {
-            get { return this.PreserveBorderEdges; }
-            set { this.PreserveBorderEdges = value; }
-        }
-
-        /// <summary>
-        /// Gets or sets if the border edges should be preserved.
-        /// Default value: false
-        /// </summary>
         public bool PreserveBorderEdges
         {
             get { return simplificationOptions.PreserveBorderEdges; }
@@ -131,32 +120,10 @@ namespace UnityMeshSimplifier
         /// Gets or sets if the UV seam edges should be preserved.
         /// Default value: false
         /// </summary>
-        [Obsolete("Use the 'MeshSimplifier.PreserveUVSeamEdges' property instead.", false)]
-        public bool PreserveSeams
-        {
-            get { return this.PreserveUVSeamEdges; }
-            set { this.PreserveUVSeamEdges = value; }
-        }
-
-        /// <summary>
-        /// Gets or sets if the UV seam edges should be preserved.
-        /// Default value: false
-        /// </summary>
         public bool PreserveUVSeamEdges
         {
             get { return simplificationOptions.PreserveUVSeamEdges; }
             set { simplificationOptions.PreserveUVSeamEdges = value; }
-        }
-
-        /// <summary>
-        /// Gets or sets if the UV foldover edges should be preserved.
-        /// Default value: false
-        /// </summary>
-        [Obsolete("Use the 'MeshSimplifier.PreserveUVFoldoverEdges' property instead.", false)]
-        public bool PreserveFoldovers
-        {
-            get { return this.PreserveUVFoldoverEdges; }
-            set { this.PreserveUVFoldoverEdges = value; }
         }
 
         /// <summary>

--- a/Runtime/MeshSimplifier.cs
+++ b/Runtime/MeshSimplifier.cs
@@ -68,7 +68,7 @@ namespace UnityMeshSimplifier
         #endregion
 
         #region Fields
-        SimplificationOptions simplificationOptions = SimplificationOptions.Default;
+        private SimplificationOptions simplificationOptions = SimplificationOptions.Default;
         private bool verbose = false;
 
         private int subMeshCount = 0;

--- a/Runtime/SimplificationOptions.cs
+++ b/Runtime/SimplificationOptions.cs
@@ -1,4 +1,4 @@
-﻿#region License
+#region License
 /*
 MIT License
 
@@ -49,7 +49,9 @@ namespace UnityMeshSimplifier
             EnableSmartLink = true,
             VertexLinkDistance = double.Epsilon,
             MaxIterationCount = 100,
-            Agressiveness = 7.0
+            Agressiveness = 7.0,
+            ManualUVComponentCount = false,
+            UVComponentCount = 2
         };
 
         /// <summary>
@@ -104,5 +106,17 @@ namespace UnityMeshSimplifier
         /// </summary>
         [Tooltip("The agressiveness of the mesh simplification. Higher number equals higher quality, but more expensive to run.")]
         public double Agressiveness;
+        /// <summary>
+        /// If a manual UV component count should be used (set by UVComponentCount), instead of the automatic detection.
+        /// Default value: false
+        /// </summary>
+        [Tooltip("If a manual UV component count should be used (set by UV Component Count below), instead of the automatic detection.")]
+        public bool ManualUVComponentCount;
+        /// <summary>
+        /// The UV component count. The same UV component count will be used on all UV channels.
+        /// Default value: 2
+        /// </summary>
+        [Range(0, 4), Tooltip("The UV component count. The same UV component count will be used on all UV channels.")]
+        public int UVComponentCount;
     }
 }

--- a/Runtime/Utility/MeshUtils.cs
+++ b/Runtime/Utility/MeshUtils.cs
@@ -287,12 +287,12 @@ namespace UnityMeshSimplifier
         /// </summary>
         /// <param name="mesh">The mesh.</param>
         /// <returns>The UV sets.</returns>
-        public static List<Vector4>[] GetMeshUVs(Mesh mesh)
+        public static IList<Vector4>[] GetMeshUVs(Mesh mesh)
         {
             if (mesh == null)
                 throw new ArgumentNullException(nameof(mesh));
 
-            var uvs = new List<Vector4>[UVChannelCount];
+            var uvs = new IList<Vector4>[UVChannelCount];
             for (int channel = 0; channel < UVChannelCount; channel++)
             {
                 uvs[channel] = GetMeshUVs(mesh, channel);
@@ -301,12 +301,48 @@ namespace UnityMeshSimplifier
         }
 
         /// <summary>
-        /// Returns the UV list for a specific mesh and UV channel.
+        /// Returns the 2D UV list for a specific mesh and UV channel.
         /// </summary>
         /// <param name="mesh">The mesh.</param>
         /// <param name="channel">The UV channel.</param>
         /// <returns>The UV list.</returns>
-        public static List<Vector4> GetMeshUVs(Mesh mesh, int channel)
+        public static IList<Vector2> GetMeshUVs2D(Mesh mesh, int channel)
+        {
+            if (mesh == null)
+                throw new ArgumentNullException(nameof(mesh));
+            else if (channel < 0 || channel >= UVChannelCount)
+                throw new ArgumentOutOfRangeException(nameof(channel));
+
+            var uvList = new List<Vector2>(mesh.vertexCount);
+            mesh.GetUVs(channel, uvList);
+            return uvList;
+        }
+
+        /// <summary>
+        /// Returns the 3D UV list for a specific mesh and UV channel.
+        /// </summary>
+        /// <param name="mesh">The mesh.</param>
+        /// <param name="channel">The UV channel.</param>
+        /// <returns>The UV list.</returns>
+        public static IList<Vector3> GetMeshUVs3D(Mesh mesh, int channel)
+        {
+            if (mesh == null)
+                throw new ArgumentNullException(nameof(mesh));
+            else if (channel < 0 || channel >= UVChannelCount)
+                throw new ArgumentOutOfRangeException(nameof(channel));
+
+            var uvList = new List<Vector3>(mesh.vertexCount);
+            mesh.GetUVs(channel, uvList);
+            return uvList;
+        }
+
+        /// <summary>
+        /// Returns the 4D UV list for a specific mesh and UV channel.
+        /// </summary>
+        /// <param name="mesh">The mesh.</param>
+        /// <param name="channel">The UV channel.</param>
+        /// <returns>The UV list.</returns>
+        public static IList<Vector4> GetMeshUVs(Mesh mesh, int channel)
         {
             if (mesh == null)
                 throw new ArgumentNullException(nameof(mesh));
@@ -323,7 +359,7 @@ namespace UnityMeshSimplifier
         /// </summary>
         /// <param name="uvs">The UV set.</param>
         /// <returns>The number of used UV components.</returns>
-        public static int GetUsedUVComponents(List<Vector4> uvs)
+        public static int GetUsedUVComponents(IList<Vector4> uvs)
         {
             if (uvs == null || uvs.Count == 0)
                 return 0;
@@ -358,7 +394,7 @@ namespace UnityMeshSimplifier
         /// </summary>
         /// <param name="uvs">The list of UVs.</param>
         /// <returns>The array of 2D UVs.</returns>
-        public static Vector2[] ConvertUVsTo2D(List<Vector4> uvs)
+        public static Vector2[] ConvertUVsTo2D(IList<Vector4> uvs)
         {
             if (uvs == null)
                 return null;
@@ -377,7 +413,7 @@ namespace UnityMeshSimplifier
         /// </summary>
         /// <param name="uvs">The list of UVs.</param>
         /// <returns>The array of 3D UVs.</returns>
-        public static Vector3[] ConvertUVsTo3D(List<Vector4> uvs)
+        public static Vector3[] ConvertUVsTo3D(IList<Vector4> uvs)
         {
             if (uvs == null)
                 return null;


### PR DESCRIPTION
Added support to set the manual UV component count when simplifying a mesh though the LOD Generator Helper component as well as through the `MeshSimplifier.Initialize` method.

Closes https://github.com/Whinarn/UnityMeshSimplifier/issues/22